### PR TITLE
feat: cv + project scoring and evaluation

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,5 @@
 import { relations, sql } from "drizzle-orm";
+import { numeric } from "drizzle-orm/pg-core";
 import { pgEnum, vector } from "drizzle-orm/pg-core";
 import { date } from "drizzle-orm/pg-core";
 import { pgTable, uuid, text, varchar, timestamp, json } from "drizzle-orm/pg-core";
@@ -72,6 +73,19 @@ export const rubricTable = pgTable('rubrics', {
     parameter: varchar('parameter').notNull(),
     description: varchar('description').notNull(),
     embedding: vector('embedding', { dimensions: 768 }),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    deletedAt: timestamp('deleted_at'),
+});
+
+export const matchingResultTable = pgTable('matching_results', {
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+    matchingId: uuid('matching_id').notNull(),
+    cvMatchRate: numeric('cv_match_rate'),
+    cvFeedback: varchar('cv_feedback'),
+    projectScore: numeric('project_score'),
+    projectFeedback: varchar('project_feedback'),
+    overallSummary: varchar('overall_summary'),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
     deletedAt: timestamp('deleted_at'),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -65,6 +65,18 @@ export const matchingTable = pgTable('matchings', {
     deletedAt: timestamp('deleted_at'),
 });
 
+export const rubricType = pgEnum('rubricType', ["cv", "project"]);
+export const rubricTable = pgTable('rubrics', {
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+    type: rubricType('type').notNull(),
+    parameter: varchar('parameter').notNull(),
+    description: varchar('description').notNull(),
+    embedding: vector('embedding', { dimensions: 768 }),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    deletedAt: timestamp('deleted_at'),
+});
+
 export const experiencesToCandidateRelation = relations(experienceTable, ({ one }) => ({
     candidate: one(candidateTable, {
         fields: [experienceTable.candidateId],

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -112,3 +112,17 @@ export const projectsToCandidateRelation = relations(projectTable, ({ one }) => 
 export const candidateToProjectsRelation = relations(candidateTable, ({ many }) => ({
     projects: many(projectTable),
 }));
+
+export const matchingResultToMatchingRelation = relations(matchingResultTable, ({ one }) => ({
+    matching: one(matchingTable, {
+        fields: [matchingResultTable.matchingId],
+        references: [matchingTable.id],
+    }),
+}));
+
+export const matchingToResultRelation = relations(matchingTable, ({ one }) => ({
+    result: one(matchingResultTable, {
+        fields: [matchingTable.id],
+        references: [matchingResultTable.matchingId],
+    }),
+}));

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -59,7 +59,7 @@ export const matchingTable = pgTable('matchings', {
     jobId: uuid('job_id').notNull(),
     candidateId: uuid('candidate_id').notNull(),
     status: matchingStatus('status').notNull().default('created'),
-    finishedAt: timestamp('finished_at').notNull().defaultNow(),
+    finishedAt: timestamp('finished_at'),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
     deletedAt: timestamp('deleted_at'),

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -81,9 +81,9 @@ export const rubricTable = pgTable('rubrics', {
 export const matchingResultTable = pgTable('matching_results', {
     id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
     matchingId: uuid('matching_id').notNull(),
-    cvMatchRate: numeric('cv_match_rate'),
+    cvMatchRate: numeric('cv_match_rate', { mode: "number" }),
     cvFeedback: varchar('cv_feedback'),
-    projectScore: numeric('project_score'),
+    projectScore: numeric('project_score', { mode: "number" }),
     projectFeedback: varchar('project_feedback'),
     overallSummary: varchar('overall_summary'),
     createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/src/routes/api/job.ts
+++ b/src/routes/api/job.ts
@@ -2,6 +2,9 @@ import { Hono } from "hono";
 import { Variables } from "@/types/hono";
 import Container from "typedi";
 import JobService from "@/services/job";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { catchZod } from "@/tools/validator";
 
 const route = new Hono<{ Variables: Variables }>();
 
@@ -12,6 +15,21 @@ route.post('/evaluate',
         c.set('data', result);
         c.status(200);
         c.set('message', 'Job evaluation is running.')
+        return c.r();
+    });
+
+route.get('/result/:id',
+    zValidator(
+        'param',
+        z.object({
+            id: z.string().uuid()
+        }), catchZod),
+    async (c, next) => {
+        const jobServiceInstance = Container.get(JobService);
+        const result = await jobServiceInstance.GetEvaluation(c.req.valid('param').id);
+        c.set('data', result);
+        c.status(200);
+        c.set('message', 'Successfully get matching evaluation.')
         return c.r();
     });
 

--- a/src/routes/api/job.ts
+++ b/src/routes/api/job.ts
@@ -1,0 +1,18 @@
+import { Hono } from "hono";
+import { Variables } from "@/types/hono";
+import Container from "typedi";
+import JobService from "@/services/job";
+
+const route = new Hono<{ Variables: Variables }>();
+
+route.post('/evaluate',
+    async (c, next) => {
+        const jobServiceInstance = Container.get(JobService);
+        const result = await jobServiceInstance.Evaluate();
+        c.set('data', result);
+        c.status(200);
+        c.set('message', 'Job evaluation is running.')
+        return c.r();
+    });
+
+export default route;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
 import { Variables } from "@/types/hono";
 import candidate from "@/routes/api/candidate";
+import job from "@/routes/api/job";
 
 export default (app: Hono<{ Variables: Variables }>) => {
-	app.route('/api/v1/candidates', candidate)
+	app.route('/api/v1/candidates', candidate);
+	app.route('/api/v1/jobs', job);
 }

--- a/src/services/genkit/flow/scoring.ts
+++ b/src/services/genkit/flow/scoring.ts
@@ -1,0 +1,204 @@
+import { z } from 'genkit';
+import { ai } from '@/services/genkit/ai';
+import Logger from "@/loaders/logger";
+import { PgDatabase } from 'drizzle-orm/pg-core';
+import Container from 'typedi';
+import { rubricTable } from '$/schema';
+import { eq, sql } from 'drizzle-orm';
+import { embed } from '@/services/genkit/tool/embed';
+
+const rubricRetreiver = ai.defineRetriever(
+    {
+        name: 'rubricRetreiver',
+        configSchema: z.object({
+            type: z.enum(['cv', 'project']),
+            k: z.number().default(5)
+        }),
+    },
+    async (input, options) => {
+        const db: PgDatabase<any> = Container.get("db");
+        const embedding = await embed(input);
+        const embeddingString = `[${embedding[0].embedding.join(',')}]`;
+        const results = await db.select({
+            id: rubricTable.id,
+            parameter: rubricTable.parameter,
+            description: rubricTable.description,
+            distance: sql<number>`embedding <=> ${embeddingString}`
+        }).from(rubricTable)
+            .where(eq(rubricTable.type, options.type))
+            .orderBy(sql`${rubricTable.embedding} <-> ${embeddingString}::vector`)
+            .limit(options.k);
+        Logger.info("FLOW scoringFlow > rubricRetreiver: %j | %j", options, results);
+        const documents = results.map(result => ({
+            content: [{ text: `Parameter: ${result.parameter}\nDescription: ${result.description}` }],
+            metadata: { id: result.id, distance: result.distance }
+        }));
+        return { documents };
+    },
+);
+
+export const scoringFlow = ai.defineFlow(
+    {
+        name: 'scoringFlow',
+        inputSchema: z.object({
+            job: z.object({
+                id: z.string().uuid().describe(''),
+                title: z.string().describe(''),
+                description: z.string().describe('')
+            }),
+            candidate: z.any(),
+        }),
+        outputSchema: z.object({
+            result: z.object({
+                cvFeedback: z.string().describe(''),
+                projectFeedback: z.string().describe(''),
+                overallSummary: z.string().describe(''),
+                cvMatchRate: z.number().describe(''),
+                projectScore: z.number().describe('')
+            }),
+            error: z.string().optional().nullable()
+        }),
+    },
+    async ({ job, candidate }) => {
+        try {
+            const keywordResponse = await ai.generate({
+                prompt: `
+You are an expert in HR and recruitment. Based on the following job posting, generate relevant keywords that can be used to search for evaluation rubrics for assessing candidate CVs and projects.
+
+## Job Posting:
+Title: ${job.title}
+Description: ${job.description}
+
+## Instructions:
+- Analyze the job title and description to identify key skills, responsibilities, qualifications, and industry-specific terms.
+- Generate keywords for CV evaluation that focus on candidate experience, skills, education, and achievements relevant to the job.
+- Generate keywords for project evaluation that focus on technical skills, project types, technologies, and outcomes demonstrated in past projects.
+- Keywords should be comma-separated lists.
+- Ensure keywords are specific, relevant, and optimized for searching evaluation rubrics or scoring criteria.
+- Limit each list to 5-10 keywords to keep it focused.
+
+Output the keywords in the following format:
+- keywordCv: [comma-separated keywords for CV]
+- keywordProject: [comma-separated keywords for projects]
+`,
+                output: {
+                    schema: z.object({
+                        keywordCv: z.string(),
+                        keywordProject: z.string()
+                    })
+                }
+            });
+
+            Logger.info("FLOW scoringFlow > keyword response %j", keywordResponse.output);
+
+            const [cvRubrics, perojectRubrics] = await Promise.all([
+                ai.retrieve({
+                    retriever: rubricRetreiver,
+                    query: keywordResponse.output.keywordCv,
+                    options: {
+                        k: 5,
+                        type: 'cv'
+                    }
+                }),
+                ai.retrieve({
+                    retriever: rubricRetreiver,
+                    query: keywordResponse.output.keywordProject,
+                    options: {
+                        k: 5,
+                        type: 'project'
+                    }
+                })
+            ]);
+
+            const scoringResponse = await ai.generate({
+                prompt: `
+You are an expert in HR and recruitment. Your task is to evaluate a candidate's CV and projects based on the provided job requirements and scoring rubrics.
+
+## Job Posting:
+Title: ${job.title}
+Description: ${job.description}
+
+## Candidate Information:
+${candidate.jobTitle}
+
+### Summary Profile:
+${candidate.summaryProfile}
+
+### Skills:
+${candidate.skills.join(',')}
+
+### Soft Skills:
+${candidate.softSkills.join(',')}
+
+### Experiences:
+${candidate.experiences.map(experience => `- ${experience.position} at ${experience.company} (${experience.startDate} - ${experience.endDate})\n${experience.description}`).join('\n')}
+
+### Projects:
+${candidate.projects.map(project => `- ${project.position} at ${project.company} (${project.startDate} - ${project.endDate})\n${project.description}`).join('\n')}
+
+## Instructions:
+1. Evaluate the candidate's CV based on the CV Scoring Rubrics. For each rubric parameter, assess how well the candidate's experience, skills, education, etc., match the description. Assign a score from 1 to 5 for each rubric (1 being poor match, 5 being excellent match).
+2. Provide concise feedback on the CV (3-5 sentences), covering strengths, gaps, and recommendations for improvement.
+3. Similarly, evaluate the candidate's projects based on the Project Scoring Rubrics, assigning scores from 1 to 5 for each.
+4. Provide concise feedback on the projects (3-5 sentences), covering strengths, gaps, and recommendations.
+5. Provide a concise overall summary of the candidate's fit for the job (3-5 sentences), combining CV and project evaluations.
+
+Output in JSON format with the following fields:
+- cvFeedback: string
+- projectFeedback: string
+- overallSummary: string
+- cvScore: array of numbers (one for each CV rubric)
+- projectScore: array of numbers (one for each project rubric)
+
+# CV Scoring Rubrics:
+${cvRubrics.map(doc => doc.content[0].text).join('\n\n')}
+
+# Project Scoring Rubrics:
+${perojectRubrics.map(doc => doc.content[0].text).join('\n\n')}`,
+                output: {
+                    schema: z.object({
+                        cvFeedback: z.string().describe(''),
+                        projectFeedback: z.string().describe(''),
+                        overallSummary: z.string().describe(''),
+                        cvScore: z.array(z.number().min(1).max(5)),
+                        projectScore: z.array(z.number().min(1).max(5))
+                    })
+                }
+            });
+
+            Logger.info("FLOW scoringFlow > scoring response %j", scoringResponse.output);
+
+            let cvMatchRate = 0;
+            const cvScoreWeight = [40, 25, 20, 15].map((weight, i) => {
+                cvMatchRate += (scoringResponse.output.cvScore?.[i] || 0) * weight / 100;
+            });
+            cvMatchRate = cvMatchRate * 20;
+
+            let projectScore = 0;
+            const projectScoreWeight = [30, 25, 20, 15, 10].map((weight, i) => {
+                projectScore += (scoringResponse.output.projectScore?.[i] || 0) * weight / 100;
+            });
+            projectScore = projectScore * 2;
+
+            Logger.info("FLOW scoringFlow > scoring cv: %s | scoring project: %s", cvMatchRate, projectScore);
+
+            return {
+                result: {
+                    cvFeedback: scoringResponse.output.cvFeedback,
+                    projectFeedback: scoringResponse.output.cvFeedback,
+                    overallSummary: scoringResponse.output.cvFeedback,
+                    cvMatchRate: cvMatchRate,
+                    projectScore: projectScore
+                },
+                error: null
+            }
+
+        } catch (error) {
+            Logger.error("FLOW scoringFlow: %s", error.message);
+            return {
+                jobs: null,
+                error: error.message
+            };
+        }
+    }
+);

--- a/src/services/job.ts
+++ b/src/services/job.ts
@@ -13,7 +13,7 @@ export default class JobService {
     ) { }
 
     public async Evaluate() {
-        this.logger.info("SVC JobService/Evaluate %s");
+        this.logger.info("SVC JobService/Evaluate");
         const matchings = await this.db
             .select({
                 id: matchingTable.id,
@@ -40,5 +40,19 @@ export default class JobService {
                 id: matchingTable.id,
                 status: matchingTable.status
             })
+    }
+
+    public async GetEvaluation(id: string) {
+        this.logger.info("SVC JobService/Evaluate > %s", id);
+        return await this.db.query.matchingTable.findFirst({
+            columns: {
+                id: true,
+                status: true
+            },
+            with: {
+                result: true
+            },
+            where: eq(matchingTable.id, id)
+        })
     }
 }

--- a/src/services/job.ts
+++ b/src/services/job.ts
@@ -1,0 +1,44 @@
+import Container, { Inject, Service } from "typedi";
+import { EventDispatcher, EventDispatcherInterface, } from "@/decorators/eventDispatcher";
+import Bull from "bull";
+import { matchingTable } from "$/schema";
+import { eq, inArray } from "drizzle-orm";
+
+@Service()
+export default class JobService {
+    constructor(
+        @Inject('logger') private logger,
+        @Inject('db') private db,
+        @EventDispatcher() private eventDispatcher: EventDispatcherInterface
+    ) { }
+
+    public async Evaluate() {
+        this.logger.info("SVC JobService/Evaluate %s");
+        const matchings = await this.db
+            .select({
+                id: matchingTable.id,
+                jobId: matchingTable.jobId,
+                candidateId: matchingTable.candidateId
+            })
+            .from(matchingTable)
+            .where(eq(matchingTable.status, 'created'));
+        const evaluateJob: Bull.Queue = Container.get('EvaluateJob');
+        const jobs = await evaluateJob.addBulk(matchings.map(matching => {
+            return {
+                data: {
+                    ...matching
+                }
+            }
+        }));
+        return await this.db
+            .update(matchingTable)
+            .set({
+                status: 'queued'
+            })
+            .where(inArray(matchingTable.id, jobs.map(job => job.data.id)))
+            .returning({
+                id: matchingTable.id,
+                status: matchingTable.status
+            })
+    }
+}


### PR DESCRIPTION
## Added:
- add rubricTable schema
- add function to seed initial rubric data
- add API `/api/v1/jobs/evaluation` to run created matching job evaluation
- implement flow for scoring and evaluation cv + project
- add API `/api/v1/jobs/result/:id` to check evaluation progress or/and result